### PR TITLE
handle blank queries, set blank query for trove

### DIFF
--- a/lib/foederati/provider.rb
+++ b/lib/foederati/provider.rb
@@ -14,14 +14,14 @@ module Foederati
     Results = Struct.new(:items, :total)
     Fields = Struct.new(:title, :thumbnail, :url)
 
-    attr_reader :id, :urls, :results, :fields, :display_name
+    attr_reader :id, :urls, :results, :fields
+    attr_accessor :display_name, :blank_query
 
     def initialize(id, &block)
       @id = id
       @urls = Urls.new
       @results = Results.new
       @fields = Fields.new
-      @display_name = ''
 
       instance_eval(&block) if block_given?
 

--- a/lib/foederati/provider/request.rb
+++ b/lib/foederati/provider/request.rb
@@ -8,7 +8,7 @@ module Foederati
     class Request
       attr_reader :provider
 
-      delegate :id, :urls, to: :provider
+      delegate :id, :urls, :blank_query, to: :provider
       delegate :connection, to: Foederati
 
       # @param provider [Foederati::Provider] the provider to make an API request for
@@ -43,6 +43,9 @@ module Foederati
       # @param params [Hash] query-specific URL parameters
       # @return [String] the provider's API URL with all necessary params
       def api_url(**params)
+        if params[:query].blank? && blank_query
+          params[:query] = blank_query
+        end
         format(urls.api, default_params.merge(params))
       end
     end

--- a/lib/foederati/providers/trove.rb
+++ b/lib/foederati/providers/trove.rb
@@ -4,6 +4,8 @@
 Foederati::Providers.register :trove do
   @display_name = 'Trove'
 
+  @blank_query = '%20'
+
   urls.api = 'http://api.trove.nla.gov.au/result?key=%{api_key}&q=%{query}&n=%{limit}&zone=picture&encoding=json'
   urls.site = 'http://trove.nla.gov.au/result?q=%{query}'
   urls.logo = 'http://trove.nla.gov.au/static/51223/img/trove-logo-home-v2.gif'
@@ -12,6 +14,6 @@ Foederati::Providers.register :trove do
   results.total = ->(response) { response['response']['zone'] ? response['response']['zone'].detect { |zone| zone['name'] == 'picture' }['records']['total'].to_i : 0 }
 
   fields.title = 'title'
-  fields.thumbnail = ->(item) { item['identifier'].detect { |identifier| identifier['linktype'] == 'thumbnail' }['value'] }
+  fields.thumbnail = ->(item) { item['identifier'] ? item['identifier'].detect { |identifier| identifier['linktype'] == 'thumbnail' }['value'] : nil }
   fields.url = 'troveUrl'
 end

--- a/spec/lib/foederati/provider/request_spec.rb
+++ b/spec/lib/foederati/provider/request_spec.rb
@@ -5,10 +5,12 @@ RSpec.describe Foederati::Provider::Request do
   let(:provider) do
     Foederati::Provider.new(:good_provider).tap do |p|
       p.urls.api = "#{api_url}?q=%{query}&k=%{api_key}&l=%{limit}"
+      p.blank_query = empty_query
     end
   end
   let(:api_url) { 'http://api.example.com/' }
   let(:query) { 'whale' }
+  let(:empty_query) { 'EMPTY' }
   let(:api_key) { 'moby' }
   let(:result_limit) { 10 }
 
@@ -68,14 +70,22 @@ RSpec.describe Foederati::Provider::Request do
   end
 
   describe '#api_url' do
-    it 'replaces placeholders in API URL with params' do
-      expect(subject.api_url(query: query)).to \
-        eq("http://api.example.com/?q=#{query}&k=#{api_key}&l=#{result_limit}")
-    end
+    context 'when the query is set' do
+      it 'replaces placeholders in API URL with params' do
+        expect(subject.api_url(query: query)).to \
+          eq("http://api.example.com/?q=#{query}&k=#{api_key}&l=#{result_limit}")
+      end
 
-    it 'overrides defaults with args' do
-      expect(subject.api_url(query: query, limit: 5)).to \
-        eq("http://api.example.com/?q=#{query}&k=#{api_key}&l=5")
+      it 'overrides defaults with args' do
+        expect(subject.api_url(query: query, limit: 5)).to \
+          eq("http://api.example.com/?q=#{query}&k=#{api_key}&l=5")
+      end
+    end
+    context 'when the query is empty' do
+      it 'replaces the query with the default empty query' do
+        expect(subject.api_url(query: '')).to \
+        eq("http://api.example.com/?q=#{empty_query}&k=#{api_key}&l=#{result_limit}")
+      end
     end
   end
 end


### PR DESCRIPTION
allow a default "blank" query to be configured for each provider and interpolate this blank query into the api request when there is no other query provided.