### PR TITLE
Provider display name and blank query

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -1,0 +1,13 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+$LOAD_PATH.unshift(File.expand_path('../../lib', __FILE__))
+
+require 'bundler/setup'
+Bundler.require(:default)
+
+Dotenv.load if defined?(Dotenv)
+
+require 'foederati'
+require 'irb'
+IRB.start

--- a/lib/foederati.rb
+++ b/lib/foederati.rb
@@ -2,6 +2,7 @@
 require 'active_support/core_ext/module/delegation'
 require 'active_support/core_ext/object/blank'
 require 'active_support/hash_with_indifferent_access'
+require 'active_support/inflector'
 require 'faraday'
 require 'faraday_middleware'
 require 'foederati/faraday_middleware'

--- a/lib/foederati/provider.rb
+++ b/lib/foederati/provider.rb
@@ -11,16 +11,17 @@ module Foederati
 
     # TODO validate the type of values added to these
     Urls = Struct.new(:api, :site, :logo)
+    DefaultParams = Struct.new(:query)
     Results = Struct.new(:items, :total)
     Fields = Struct.new(:title, :thumbnail, :url)
 
-    attr_reader :id, :urls, :results, :fields
+    attr_reader :id, :urls, :default_params, :results, :fields
     attr_writer :name
-    attr_accessor :blank_query
 
     def initialize(id, &block)
       @id = id
       @urls = Urls.new
+      @default_params = DefaultParams.new
       @results = Results.new
       @fields = Fields.new
 

--- a/lib/foederati/provider.rb
+++ b/lib/foederati/provider.rb
@@ -15,7 +15,8 @@ module Foederati
     Fields = Struct.new(:title, :thumbnail, :url)
 
     attr_reader :id, :urls, :results, :fields
-    attr_accessor :display_name, :blank_query
+    attr_writer :name
+    attr_accessor :blank_query
 
     def initialize(id, &block)
       @id = id
@@ -26,6 +27,10 @@ module Foederati
       instance_eval(&block) if block_given?
 
       self
+    end
+
+    def name
+      @name || id.to_s.titleize
     end
 
     # TODO sanity check things like presence of API URL

--- a/lib/foederati/providers/digitalnz.rb
+++ b/lib/foederati/providers/digitalnz.rb
@@ -2,7 +2,7 @@
 
 # DigitalNZ
 Foederati::Providers.register :digitalnz do
-  @display_name = 'Digital NZ'
+  self.name = 'DigitalNZ'
 
   urls.api = 'https://api.digitalnz.org/v3/records.json?api_key=%{api_key}&text=%{query}&per_page=%{limit}'
   urls.site = 'https://digitalnz.org/records?text=%{query}'

--- a/lib/foederati/providers/dpla.rb
+++ b/lib/foederati/providers/dpla.rb
@@ -2,7 +2,7 @@
 
 # DPLA
 Foederati::Providers.register :dpla do
-  @display_name = 'DPLA'
+  self.name = 'DPLA'
 
   urls.api = 'https://api.dp.la/v2/items?api_key=%{api_key}&q=%{query}&page_size=%{limit}'
   urls.site = 'https://dp.la/search?q=%{query}'

--- a/lib/foederati/providers/europeana.rb
+++ b/lib/foederati/providers/europeana.rb
@@ -2,8 +2,6 @@
 
 # Europeana
 Foederati::Providers.register :europeana do
-  @display_name = 'Europeana'
-
   urls.api = 'https://www.europeana.eu/api/v2/search.json?wskey=%{api_key}&query=%{query}&rows=%{limit}&profile=minimal'
   urls.site = 'http://www.europeana.eu/portal/search?q=%{query}'
   urls.logo = ''

--- a/lib/foederati/providers/trove.rb
+++ b/lib/foederati/providers/trove.rb
@@ -2,8 +2,6 @@
 
 # Trove
 Foederati::Providers.register :trove do
-  @display_name = 'Trove'
-
   @blank_query = '%20'
 
   urls.api = 'http://api.trove.nla.gov.au/result?key=%{api_key}&q=%{query}&n=%{limit}&zone=picture&encoding=json'

--- a/lib/foederati/providers/trove.rb
+++ b/lib/foederati/providers/trove.rb
@@ -2,17 +2,21 @@
 
 # Trove
 Foederati::Providers.register :trove do
-  @blank_query = '%20'
-
   urls.api = 'http://api.trove.nla.gov.au/result?key=%{api_key}&q=%{query}&n=%{limit}&zone=picture&encoding=json'
   urls.site = 'http://trove.nla.gov.au/result?q=%{query}'
   urls.logo = 'http://trove.nla.gov.au/static/51223/img/trove-logo-home-v2.gif'
 
-  results.items = ->(response) { response['response']['zone'] ? response['response']['zone'].detect { |zone| zone['name'] == 'picture' }['records']['work'] : [] }
-  results.total = ->(response) { response['response']['zone'] ? response['response']['zone'].detect { |zone| zone['name'] == 'picture' }['records']['total'].to_i : 0 }
+  default_params.query = '%20'
+
+  results.items = lambda do |response|
+    response['response']['zone'] ? response['response']['zone'].detect { |zone| zone['name'] == 'picture' }['records']['work'] : []
+  end
+  results.total = lambda do |response|
+    response['response']['zone'] ? response['response']['zone'].detect { |zone| zone['name'] == 'picture' }['records']['total'].to_i : 0
+  end
 
   fields.title = 'title'
-  fields.thumbnail = ->(item) do
+  fields.thumbnail = lambda do |item|
     if item['identifier']
       thumb_identifier = item['identifier'].detect { |identifier| identifier['linktype'] == 'thumbnail' }
       thumb_identifier ? thumb_identifier['value'] : nil

--- a/spec/lib/foederati/provider/request_spec.rb
+++ b/spec/lib/foederati/provider/request_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Foederati::Provider::Request do
   let(:provider) do
     Foederati::Provider.new(:good_provider).tap do |p|
       p.urls.api = "#{api_url}?q=%{query}&k=%{api_key}&l=%{limit}"
-      p.blank_query = empty_query
+      p.default_params.query = empty_query
     end
   end
   let(:api_url) { 'http://api.example.com/' }

--- a/spec/lib/foederati/provider_spec.rb
+++ b/spec/lib/foederati/provider_spec.rb
@@ -20,9 +20,21 @@ RSpec.describe Foederati::Provider do
     it { is_expected.to respond_to :url }
   end
 
-  describe '#display_name' do
+  describe '#name' do
     subject { described_class.new(:new_provider) }
-    it { is_expected.to respond_to :display_name }
+
+    context 'when not set' do
+      it 'is derived from ID' do
+        expect(subject.name).to eq('New Provider')
+      end
+    end
+
+    context 'when set' do
+      it 'is returned as set' do
+        subject.name = 'Nice name'
+        expect(subject.name).to eq('Nice name')
+      end
+    end
   end
 
   describe '#initialize' do

--- a/spec/lib/foederati/provider_spec.rb
+++ b/spec/lib/foederati/provider_spec.rb
@@ -7,6 +7,11 @@ RSpec.describe Foederati::Provider do
     it { is_expected.to respond_to :logo }
   end
 
+  describe '#default_params' do
+    subject { described_class.new(:new_provider).default_params }
+    it { is_expected.to respond_to :query }
+  end
+
   describe '#results' do
     subject { described_class.new(:new_provider).results }
     it { is_expected.to respond_to :items }

--- a/spec/lib/foederati/providers/digitalnz_spec.rb
+++ b/spec/lib/foederati/providers/digitalnz_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+RSpec.describe Foederati::Providers do
+  it 'has registered DigitalNZ' do
+    expect(described_class.registry).to have_key(:digitalnz)
+  end
+
+  describe 'DigitalNZ provider' do
+    let(:provider) { described_class.get(:digitalnz) }
+
+    describe '#name' do
+      subject { provider.name }
+      it { is_expected.to eq('DigitalNZ') }
+    end
+  end
+end

--- a/spec/lib/foederati/providers/dpla_spec.rb
+++ b/spec/lib/foederati/providers/dpla_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+RSpec.describe Foederati::Providers do
+  it 'has registered DPLA' do
+    expect(described_class.registry).to have_key(:dpla)
+  end
+
+  describe 'DPLA provider' do
+    let(:provider) { described_class.get(:dpla) }
+
+    describe '#name' do
+      subject { provider.name }
+      it { is_expected.to eq('DPLA') }
+    end
+  end
+end

--- a/spec/lib/foederati/providers/europeana_spec.rb
+++ b/spec/lib/foederati/providers/europeana_spec.rb
@@ -3,4 +3,13 @@ RSpec.describe Foederati::Providers do
   it 'has registered Europeana' do
     expect(described_class.registry).to have_key(:europeana)
   end
+
+  describe 'Europeana provider' do
+    let(:provider) { described_class.get(:europeana) }
+
+    describe '#name' do
+      subject { provider.name }
+      it { is_expected.to eq('Europeana') }
+    end
+  end
 end

--- a/spec/lib/foederati/providers/trove_spec.rb
+++ b/spec/lib/foederati/providers/trove_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+RSpec.describe Foederati::Providers do
+  it 'has registered Trove' do
+    expect(described_class.registry).to have_key(:trove)
+  end
+
+  describe 'Trove provider' do
+    let(:provider) { described_class.get(:trove) }
+
+    describe '#name' do
+      subject { provider.name }
+      it { is_expected.to eq('Trove') }
+    end
+  end
+end

--- a/spec/lib/foederati/providers/trove_spec.rb
+++ b/spec/lib/foederati/providers/trove_spec.rb
@@ -11,5 +11,12 @@ RSpec.describe Foederati::Providers do
       subject { provider.name }
       it { is_expected.to eq('Trove') }
     end
+
+    describe '#default_params' do
+      describe '#query' do
+        subject { provider.default_params.query }
+        it { is_expected.to eq('%20') }
+      end
+    end
   end
 end


### PR DESCRIPTION
* Setting instance variables directly in provider declarations undermines the DSL
* Provider (display) names can often be derived from their ID